### PR TITLE
chore: add and improve current interfaces to match backend

### DIFF
--- a/src/api/contacts.ts
+++ b/src/api/contacts.ts
@@ -21,15 +21,7 @@ export class Contacts {
    * @returns The created contact
    */
   async create(options: ContactCreateOptions): Promise<Contact> {
-    const { customProperties, ...rest } = options;
-
-    const response = await this.httpClient.post<{ contact: Contact }>('/contacts', {
-      // Transform the input format to the backend expected format
-      properties: {
-        ...rest,
-        ...(customProperties || {}),
-      },
-    });
+    const response = await this.httpClient.post<{ contact: Contact }>('/contacts', options);
     return response.contact;
   }
 
@@ -62,15 +54,7 @@ export class Contacts {
    * @returns The updated contact
    */
   async update(id: string, options: Partial<ContactCreateOptions>): Promise<Contact> {
-    const { customProperties, ...rest } = options;
-
-    const response = await this.httpClient.put<{ contact: Contact }>(`/contacts/${id}`, {
-      // Transform the input format to the backend expected format
-      properties: {
-        ...rest,
-        ...(customProperties || {}),
-      },
-    });
+    const response = await this.httpClient.put<{ contact: Contact }>(`/contacts/${id}`, options);
     return response.contact;
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -141,6 +141,13 @@ export {
   SmashsendContactStatus,
   SmashsendCountryCode,
   SmashsendPropertyType,
+  SmashsendApiKeyRole,
+  SmashsendApiKeyStatus,
+  SmashsendContactSource,
+  SmashsendContactPropertyFilterType,
+  SmashsendWebhookStatus,
+  SmashsendWebhookEvent,
+  TransactionalEmailStatus,
 } from './interfaces/types';
 
 export {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -477,7 +477,6 @@ export interface CustomProperty {
 }
 
 export interface CustomPropertyCreateOptions {
-  apiSlug: string;
   displayName: string;
   type: SmashsendPropertyType;
   description?: string;


### PR DESCRIPTION
we were having tons of missing interfaces or even using generic types like strings, instead of fully define them with enums. This PR fixes that

- Adds missing interfaces
- Updates some of the current interfaces with the right payload