### PR TITLE
feat: allow custom "replyTo" for transactional (both on raw and templated)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ const response = await smashsend.emails.send({
     <a href="https://track.example.com/12345">Track your package</a>
   `,
   text: 'Your order #12345 has shipped. Track at: https://track.example.com/12345',
+  replyTo: 'support@yourdomain.com', // Optional: set reply-to address
   groupBy: 'order-shipped', // Group analytics by email type
   settings: {
     trackClicks: true,
@@ -144,6 +145,64 @@ const response = await smashsend.emails.sendWithTemplate({
 console.log(response.messageId); // Unique ID for tracking
 console.log(response.status); // SCHEDULED, SENT, etc.
 ```
+
+## Dynamic Reply-To Addresses
+
+Both raw emails and templated emails support dynamic `replyTo` configuration:
+
+### Raw Emails
+
+```typescript
+// Single reply-to address
+await smashsend.emails.send({
+  from: 'notifications@yourdomain.com',
+  to: 'user@example.com',
+  subject: 'Welcome!',
+  html: '<h1>Welcome to our service!</h1>',
+  replyTo: 'support@yourdomain.com'
+});
+
+// Multiple reply-to addresses
+await smashsend.emails.send({
+  from: 'notifications@yourdomain.com',
+  to: 'user@example.com',
+  subject: 'Urgent Support Request',
+  html: '<h1>We received your support request</h1>',
+  replyTo: ['support@yourdomain.com', 'urgent@yourdomain.com']
+});
+```
+
+### Templated Emails with Dynamic Reply-To
+
+For templated emails, the `replyTo` parameter **overrides** the reply-to address configured in your template:
+
+```typescript
+// Uses template's default reply-to (no override)
+await smashsend.emails.sendWithTemplate({
+  template: 'welcome-email',
+  to: 'user@example.com',
+  variables: { name: 'John' }
+  // No replyTo - uses template's configured reply-to
+});
+
+// Override with single reply-to
+await smashsend.emails.sendWithTemplate({
+  template: 'billing-reminder',
+  to: 'user@example.com',
+  variables: { amount: '$29.99', dueDate: '2024-01-15' },
+  replyTo: 'billing@yourdomain.com' // Overrides template's reply-to
+});
+
+// Override with multiple reply-to addresses
+await smashsend.emails.sendWithTemplate({
+  template: 'support-ticket',
+  to: 'user@example.com',
+  variables: { ticketId: 'TICKET-12345' },
+  replyTo: ['support@yourdomain.com', 'escalation@yourdomain.com']
+});
+```
+
+> **💡 Fallback behavior:** If you don't specify `replyTo` in templated emails, SMASHSEND automatically uses the reply-to address configured in your template settings. This gives you the flexibility to override it when needed while maintaining sensible defaults.
 
 ## Send email with React
 

--- a/examples/replyTo-examples.js
+++ b/examples/replyTo-examples.js
@@ -1,0 +1,99 @@
+/**
+ * Examples demonstrating dynamic replyTo functionality
+ * 
+ * This feature allows you to dynamically override reply-to addresses
+ * when sending transactional emails, with fallback to template settings.
+ */
+
+const { SmashSend } = require('../dist/index.js');
+
+const smashsend = new SmashSend({
+  apiKey: process.env.SMASHSEND_API_KEY || 'your-api-key-here'
+});
+
+async function demonstrateReplyToFeatures() {
+  try {
+    console.log('🚀 Testing dynamic replyTo functionality...\n');
+
+    // Example 1: Raw email with single replyTo
+    console.log('1. Raw email with single replyTo:');
+    const rawEmailSingle = await smashsend.emails.send({
+      from: 'sender@example.com',
+      to: 'recipient@example.com',
+      subject: 'Test with Single Reply-To',
+      html: '<h1>Hello!</h1><p>This email has a single reply-to address.</p>',
+      replyTo: 'support@example.com' // Single email string
+    });
+    console.log('✅ Sent:', rawEmailSingle.messageId);
+
+    // Example 2: Raw email with multiple replyTo addresses
+    console.log('\n2. Raw email with multiple replyTo addresses:');
+    const rawEmailMultiple = await smashsend.emails.send({
+      from: 'sender@example.com',
+      to: 'recipient@example.com',
+      subject: 'Test with Multiple Reply-To',
+      html: '<h1>Hello!</h1><p>This email has multiple reply-to addresses.</p>',
+      replyTo: ['support@example.com', 'sales@example.com'] // Array of emails
+    });
+    console.log('✅ Sent:', rawEmailMultiple.messageId);
+
+    // Example 3: Templated email without replyTo (uses template default)
+    console.log('\n3. Templated email using template default replyTo:');
+    const templatedDefault = await smashsend.emails.sendWithTemplate({
+      template: 'welcome-email',
+      to: 'recipient@example.com',
+      variables: { name: 'John Doe' }
+      // No replyTo specified - will use template's configured replyTo
+    });
+    console.log('✅ Sent:', templatedDefault.messageId);
+
+    // Example 4: Templated email with dynamic single replyTo override
+    console.log('\n4. Templated email with dynamic single replyTo override:');
+    const templatedSingle = await smashsend.emails.sendWithTemplate({
+      template: 'welcome-email',
+      to: 'recipient@example.com',
+      variables: { name: 'Jane Doe' },
+      replyTo: 'custom-support@example.com' // Overrides template's replyTo
+    });
+    console.log('✅ Sent:', templatedSingle.messageId);
+
+    // Example 5: Templated email with dynamic multiple replyTo override
+    console.log('\n5. Templated email with dynamic multiple replyTo override:');
+    const templatedMultiple = await smashsend.emails.sendWithTemplate({
+      template: 'support-ticket',
+      to: 'recipient@example.com',
+      variables: { 
+        ticketId: 'TICKET-12345',
+        priority: 'High'
+      },
+      replyTo: ['urgent@example.com', 'escalation@example.com'] // Multiple overrides
+    });
+    console.log('✅ Sent:', templatedMultiple.messageId);
+
+    console.log('\n🎉 All examples completed successfully!');
+    console.log('\n📖 How it works:');
+    console.log('   • For raw emails: replyTo is always used if provided');
+    console.log('   • For templated emails: replyTo overrides template settings');
+    console.log('   • If no replyTo provided: falls back to template configuration');
+    console.log('   • Supports both single email strings and arrays of emails');
+
+  } catch (error) {
+    console.error('❌ Error:', error.message);
+    
+    if (error.data) {
+      console.error('   Additional info:', error.data);
+    }
+    
+    if (error.message.includes('api-key-here')) {
+      console.log('\n💡 Tip: Set your SMASHSEND_API_KEY environment variable');
+      console.log('   export SMASHSEND_API_KEY="your-actual-api-key"');
+    }
+  }
+}
+
+// Only run if this file is executed directly
+if (require.main === module) {
+  demonstrateReplyToFeatures();
+}
+
+module.exports = { demonstrateReplyToFeatures };

--- a/src/api/emails.ts
+++ b/src/api/emails.ts
@@ -29,11 +29,30 @@ export class Emails {
    *
    * @example
    * ```ts
+   * // Basic usage
    * await smashsend.emails.send({
    *   from: 'John <john@acme.com>',
    *   to: 'jane@example.com',
    *   subject: 'Hi there!',
    *   html: '<strong>Welcome</strong>',
+   * });
+   * 
+   * // With dynamic replyTo
+   * await smashsend.emails.send({
+   *   from: 'John <john@acme.com>',
+   *   to: 'jane@example.com',
+   *   subject: 'Hi there!',
+   *   html: '<strong>Welcome</strong>',
+   *   replyTo: 'support@acme.com', // Single email
+   * });
+   * 
+   * // With multiple replyTo addresses
+   * await smashsend.emails.send({
+   *   from: 'John <john@acme.com>',
+   *   to: 'jane@example.com',
+   *   subject: 'Hi there!',
+   *   html: '<strong>Welcome</strong>',
+   *   replyTo: ['support@acme.com', 'sales@acme.com'], // Array of emails
    * });
    * ```
    */
@@ -95,15 +114,41 @@ export class Emails {
 
   /**
    * Send an email **using a stored template**.
+   * 
+   * The `replyTo` parameter allows you to dynamically override the reply-to address(es) 
+   * configured in your template. If not provided, the template's configured replyTo 
+   * setting will be used as a fallback.
    *
    * @example
    * ```ts
+   * // Basic usage - uses template's default replyTo
    * await smashsend.emails.sendWithTemplate({
    *   template: 'payment-received',
    *   to: 'jane@example.com',
    *   variables: { amount: 42 },
    * });
+   * 
+   * // Override replyTo with a single email
+   * await smashsend.emails.sendWithTemplate({
+   *   template: 'payment-received',
+   *   to: 'jane@example.com',
+   *   variables: { amount: 42 },
+   *   replyTo: 'billing@acme.com', // Overrides template's replyTo
+   * });
+   * 
+   * // Override replyTo with multiple emails
+   * await smashsend.emails.sendWithTemplate({
+   *   template: 'support-ticket',
+   *   to: 'jane@example.com',
+   *   variables: { ticketId: 'TICKET-123' },
+   *   replyTo: ['support@acme.com', 'urgent@acme.com'], // Multiple reply addresses
+   * });
    * ```
+   * 
+   * @param options.replyTo - Optional reply-to address(es). Can be:
+   *   - A single email string: `'support@acme.com'`
+   *   - An array of email strings: `['support@acme.com', 'sales@acme.com']`
+   *   - If not provided, falls back to the template's configured replyTo setting
    */
   async sendWithTemplate(options: TemplatedEmailSendOptions): Promise<TemplatedEmailSendResponse> {
     const response = await this.httpClient.post<{ email: TemplatedEmailSendResponse }>('/emails', {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -52,8 +52,8 @@ interface RawEmailSendOptionsBase {
   subject: string;
   /** Optional preview / pre-header text shown by email clients. */
   previewText?: string;
-  /** Optional reply-to address. */
-  replyTo?: string;
+  /** Optional reply-to address(es). Can be a single email string or array of email strings. If not provided, falls back to the template's replyTo setting. */
+  replyTo?: string | string[];
   /** Optional plain-text body. If omitted Smashsend will auto-generate from HTML. */
   text?: string;
   /** Optional map of contact properties to upsert before sending. */
@@ -82,6 +82,8 @@ export interface TemplatedEmailSendOptions {
   to: string;
   /** Key-value pairs used to render the template. */
   variables?: Record<string, any>;
+  /** Optional reply-to address(es). Can be a single email string or array of email strings. If not provided, falls back to the template's replyTo setting. */
+  replyTo?: string | string[];
   /** Tracking configuration. */
   settings?: {
     trackClicks?: boolean;


### PR DESCRIPTION
SMASHSEND Email API now supports replyTo! This PR adds that to our SDK