### PR TITLE
feat: Dynamic Reply-To Arrays with Auto-Deduplication 🎯

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Dynamic Reply-To Addresses**: Added support for custom reply-to addresses in both raw and templated emails
+  - 📧 **Multiple addresses**: Support for up to 5 reply-to addresses per email
+  - 🔄 **Flexible input**: Accept single email string or array of email strings
+  - 🧹 **Automatic deduplication**: Duplicate addresses are automatically removed (case-insensitive)
+  - 📝 **Template override**: Dynamic reply-to addresses override template defaults for templated emails
+  - ✅ **Full validation**: Proper error messages when limits are exceeded
+  - 🎯 **Both email types**: Works with both `emails.send()` (raw) and `emails.sendWithTemplate()` (templated)
+
 - **Data Migration Support**: Added `overrideCreatedAt` parameter for batch contact operations
   - ⚠️ **MIGRATION USE ONLY**: Allows preserving historical creation dates when migrating from legacy systems
   - Added `createdAt` field to `ContactCreateOptions` interface (Date type, automatically converted to ISO string)

--- a/README.md
+++ b/README.md
@@ -204,6 +204,51 @@ console.log(response.messageId); // Unique ID for tracking
 console.log(response.status); // SCHEDULED, SENT, etc.
 ```
 
+## Reply-To Addresses
+
+You can specify custom reply-to addresses for both raw and templated emails. This allows recipients to reply to different addresses than the sender.
+
+**Single reply-to address:**
+
+```typescript
+await smashsend.emails.send({
+  from: 'noreply@yourdomain.com',
+  to: 'customer@example.com',
+  subject: 'Support Request Received',
+  html: '<p>We received your support request and will respond soon.</p>',
+  replyTo: 'support@yourdomain.com', // Single address
+});
+```
+
+**Multiple reply-to addresses (max 5):**
+
+```typescript
+await smashsend.emails.send({
+  from: 'noreply@yourdomain.com', 
+  to: 'customer@example.com',
+  subject: 'Welcome to our platform',
+  html: '<p>Welcome! Contact us if you need help.</p>',
+  replyTo: [
+    'support@yourdomain.com',
+    'sales@yourdomain.com',
+    'billing@yourdomain.com'
+  ], // Multiple addresses
+});
+```
+
+**With templates:**
+
+```typescript
+await smashsend.emails.sendWithTemplate({
+  template: 'welcome-email',
+  to: 'user@example.com',
+  variables: { firstName: 'John' },
+  replyTo: ['support@yourdomain.com', 'welcome@yourdomain.com'], // Overrides template default
+});
+```
+
+> **💡 Note:** Dynamic reply-to addresses override any reply-to settings configured in the template. If no dynamic reply-to is provided, the template's reply-to setting is used. Duplicate addresses are automatically removed.
+
 ## Send email with React
 
 For developers using React, you can write emails as React components:

--- a/src/__tests__/emails.test.ts
+++ b/src/__tests__/emails.test.ts
@@ -145,6 +145,111 @@ describe('Emails', () => {
       });
       expect(result).toEqual(mockResponse);
     });
+
+    it('should handle single replyTo address', async () => {
+      // Setup mock response
+      const mockResponse = {
+        id: 'email-id',
+        from: 'test@example.com',
+        to: ['recipient@example.com'],
+        created: '2023-01-01T00:00:00Z',
+        statusCode: 200,
+        message: 'Email sent successfully',
+      };
+
+      // Setup the mock
+      mockHttpClient.post.mockResolvedValueOnce({ email: mockResponse });
+
+      // Call the method with single replyTo
+      const result = await emails.send({
+        from: 'test@example.com',
+        to: 'recipient@example.com',
+        subject: 'Test Email',
+        html: '<p>Hello World</p>',
+        replyTo: 'support@example.com',
+      });
+
+      // Assertions
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/emails', {
+        from: 'test@example.com',
+        to: 'recipient@example.com',
+        subject: 'Test Email',
+        html: '<p>Hello World</p>',
+        replyTo: 'support@example.com',
+        sendAt: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('should handle array of replyTo addresses', async () => {
+      // Setup mock response
+      const mockResponse = {
+        id: 'email-id',
+        from: 'test@example.com',
+        to: ['recipient@example.com'],
+        created: '2023-01-01T00:00:00Z',
+        statusCode: 200,
+        message: 'Email sent successfully',
+      };
+
+      // Setup the mock
+      mockHttpClient.post.mockResolvedValueOnce({ email: mockResponse });
+
+      // Call the method with array of replyTo addresses
+      const result = await emails.send({
+        from: 'test@example.com',
+        to: 'recipient@example.com',
+        subject: 'Test Email',
+        html: '<p>Hello World</p>',
+        replyTo: ['support@example.com', 'sales@example.com'],
+      });
+
+      // Assertions
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/emails', {
+        from: 'test@example.com',
+        to: 'recipient@example.com',
+        subject: 'Test Email',
+        html: '<p>Hello World</p>',
+        replyTo: ['support@example.com', 'sales@example.com'],
+        sendAt: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('sendWithTemplate', () => {
+    it('should handle replyTo in templated emails', async () => {
+      // Setup mock response
+      const mockResponse = {
+        id: 'email-id',
+        template: 'welcome-email',
+        to: 'recipient@example.com',
+        created: '2023-01-01T00:00:00Z',
+        statusCode: 200,
+        message: 'Email sent successfully',
+      };
+
+      // Setup the mock
+      mockHttpClient.post.mockResolvedValueOnce({ email: mockResponse });
+
+      // Call the method with replyTo
+      const result = await emails.sendWithTemplate({
+        template: 'welcome-email',
+        to: 'recipient@example.com',
+        variables: { firstName: 'John' },
+        replyTo: ['support@example.com', 'welcome@example.com'],
+      });
+
+      // Assertions
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/emails', {
+        template: 'welcome-email',
+        to: 'recipient@example.com',
+        variables: { firstName: 'John' },
+        replyTo: ['support@example.com', 'welcome@example.com'],
+        sendAt: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+    });
   });
 
   describe('transactional.list', () => {

--- a/src/interfaces/types.ts
+++ b/src/interfaces/types.ts
@@ -52,8 +52,8 @@ interface RawEmailSendOptionsBase {
   subject: string;
   /** Optional preview / pre-header text shown by email clients. */
   previewText?: string;
-  /** Optional reply-to address. */
-  replyTo?: string;
+  /** Optional reply-to address(es). Can be a single email string or array of email strings (max 5). */
+  replyTo?: string | string[];
   /** Optional plain-text body. If omitted Smashsend will auto-generate from HTML. */
   text?: string;
   /** Optional map of contact properties to upsert before sending. */
@@ -82,6 +82,8 @@ export interface TemplatedEmailSendOptions {
   to: string;
   /** Key-value pairs used to render the template. */
   variables?: Record<string, any>;
+  /** Optional reply-to address(es). Can be a single email string or array of email strings (max 5). If not provided, falls back to the template's replyTo setting. */
+  replyTo?: string | string[];
   /** Tracking configuration. */
   settings?: {
     trackClicks?: boolean;


### PR DESCRIPTION
love this!! SMASHSEND Email API now introduces a new way to pass custom "reply-to" addresses. 

This works both on: raw emails and templated emails.

```ts
await smashsend.emails.send({
  from: 'noreply@yourdomain.com',
  to: 'customer@example.com', 
  subject: 'Order Confirmation',
  html: '<p>Your order has been confirmed!</p>',
  replyTo: ['support@yourdomain.com', 'billing@yourdomain.com'], // ✅ New!
});
```

```ts
await smashsend.emails.sendWithTemplate({
  template: 'welcome-email',
  to: 'user@example.com',
  variables: { firstName: 'John' },
  replyTo: 'support@yourdomain.com', // ✅ Overrides template default
});
```


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds support for single or multiple reply-to addresses (max 5) across raw and templated emails, with updated types, docs, and tests.
> 
> - **Emails API**
>   - Support dynamic `replyTo` in `emails.send()` and `emails.sendWithTemplate()` (accepts `string | string[]`, up to 5; deduplication noted in docs).
> - **Types**
>   - Update `RawEmailSendOptions.replyTo` to `string | string[]` in `src/interfaces/types.ts`.
>   - Add `replyTo?: string | string[]` to `TemplatedEmailSendOptions`.
> - **Tests**
>   - Add tests for single and multiple `replyTo` in `send()` and for `replyTo` in `sendWithTemplate()` in `src/__tests__/emails.test.ts`.
> - **Docs**
>   - README: New "Reply-To Addresses" section with single/multiple/template examples and note on overrides/deduplication.
>   - CHANGELOG: Entry for Dynamic Reply-To Addresses with limits, validation, and template override details.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 44356a3ca3775cd4ab3db1d8d14befb8acfd9f82. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->