### PR TITLE
feat: add Forms API (hosted forms + referral waitlists)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Forms API**: `smashsend.forms.*` — hosted forms and the referral/waitlist system
+  - `forms.get()` — read a published form's questions (supports password-protected forms)
+  - `forms.submit()` — submit a response, with `countryCode` so server-side submissions
+    are not geo-located to your datacenter, and `referralCode` to credit the sharer
+  - `forms.getReferralStatus()` — a participant's position, points, share link and task states
+  - `forms.completeTask()` — complete a referral task, with proof for manual tasks
+  - `forms.sendStatusLink()` — email a returning participant their personal link
+  - `forms.getLeaderboard()` — masked (public key) or unmasked (form id + API key)
+  - `forms.getEntryPosition()` — position by entry id or email (customer API)
+  - `forms.listEntryRewards()` — the points ledger for one entry (customer API)
+  - Full TypeScript types exported; `countryCode` reuses the existing `SmashsendCountryCode` enum
+
 - **New Feature**: `contacts.deleteByEmail()` method for deleting contacts by email address
   - Added `deleteByEmail(email: string)` method to Contacts API
   - Properly handles URL encoding of email addresses with special characters

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Forms API**: `smashsend.forms.*` — hosted forms and the referral/waitlist system
-  - `forms.get()` — read a published form's questions (supports password-protected forms)
+  - `forms.getByPublicKey()` — read a published form's questions (supports password-protected forms)
   - `forms.submit()` — submit a response, with `countryCode` so server-side submissions
     are not geo-located to your datacenter, and `referralCode` to credit the sharer
   - `forms.getReferralStatus()` — a participant's position, points, share link and task states

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **Forms API**: `smashsend.forms.*` — hosted forms and the referral/waitlist system
-  - `forms.getByPublicKey()` — read a published form's questions (supports password-protected forms)
+  - `forms.getPublicForm()` — read a published form's questions (supports password-protected forms)
   - `forms.submit()` — submit a response, with `countryCode` so server-side submissions
     are not geo-located to your datacenter, and `referralCode` to credit the sharer
   - `forms.getReferralStatus()` — a participant's position, points, share link and task states

--- a/README.md
+++ b/README.md
@@ -398,14 +398,14 @@ if (entry.status === 'PENDING') {
 **Read a form's questions:**
 
 ```typescript
-const { form } = await smashsend.forms.getByPublicKey('pk_abc123');
+const { form } = await smashsend.forms.getPublicForm('pk_abc123');
 
 form.config?.fields.forEach((field) => {
   console.log(`${field.key} (${field.type}): ${field.label}`);
 });
 
 // Password-protected forms only return `config` with the right password
-const protectedForm = await smashsend.forms.getByPublicKey('pk_abc123', {
+const protectedForm = await smashsend.forms.getPublicForm('pk_abc123', {
   password: 'hunter2',
 });
 ```
@@ -481,8 +481,9 @@ rewards.items.forEach((reward) => {
 - A form can restrict which domains may read and submit it ("Allowed domains" in
   its settings). That check is skipped for calls carrying your API key — it keys
   off the browser's `Origin` header, which server-side callers don't send.
-- Methods that take a `publicKey` say so in the name; `forms.get(formId)` is
-  reserved for the workspace-scoped lookup, which the API does not expose yet.
+- `getPublicForm()` returns the public view of a form (the questions a
+  respondent sees). `forms.get(formId)` is reserved for the workspace-scoped
+  lookup, which the API does not expose yet.
 - Submissions are deduplicated per (form, email): submitting the same email
   twice returns the existing entry instead of creating a duplicate.
 - `position`, `peopleAhead` and `participantTotal` include any display offsets

--- a/README.md
+++ b/README.md
@@ -398,14 +398,14 @@ if (entry.status === 'PENDING') {
 **Read a form's questions:**
 
 ```typescript
-const { form } = await smashsend.forms.get('pk_abc123');
+const { form } = await smashsend.forms.getByPublicKey('pk_abc123');
 
 form.config?.fields.forEach((field) => {
   console.log(`${field.key} (${field.type}): ${field.label}`);
 });
 
 // Password-protected forms only return `config` with the right password
-const protectedForm = await smashsend.forms.get('pk_abc123', {
+const protectedForm = await smashsend.forms.getByPublicKey('pk_abc123', {
   password: 'hunter2',
 });
 ```
@@ -478,6 +478,11 @@ rewards.items.forEach((reward) => {
 
 **Notes**
 
+- A form can restrict which domains may read and submit it ("Allowed domains" in
+  its settings). That check is skipped for calls carrying your API key — it keys
+  off the browser's `Origin` header, which server-side callers don't send.
+- Methods that take a `publicKey` say so in the name; `forms.get(formId)` is
+  reserved for the workspace-scoped lookup, which the API does not expose yet.
 - Submissions are deduplicated per (form, email): submitting the same email
   twice returns the existing entry instead of creating a duplicate.
 - `position`, `peopleAhead` and `participantTotal` include any display offsets

--- a/README.md
+++ b/README.md
@@ -352,6 +352,140 @@ if (result.errors?.length > 0) {
 - `timestamp`: Event timestamp (optional, defaults to current time)
 - `messageId`: Custom ID for deduplication (optional, auto-generated if not provided)
 
+## Forms API
+
+Read your hosted forms, submit responses server-side, and drive the referral
+("viral waitlist") loop: positions, points, tasks and leaderboards.
+
+Endpoints come in two flavours. **Public** ones are keyed by the form's
+`publicKey` and need no API key — they are what a browser or your backend calls
+on behalf of the person filling the form. **Customer API** ones are keyed by the
+form `id` and require your workspace API key.
+
+**Submit a response (server-side):**
+
+```typescript
+import { SmashSend, SmashsendCountryCode } from '@smashsend/node';
+
+const smashsend = new SmashSend('smashsend_xxxxxxxxxxxx');
+
+const { entry } = await smashsend.forms.submit('pk_abc123', {
+  email: 'jane@example.com',
+  answers: {
+    firstName: 'Jane',
+    company: 'Acme',
+  },
+  // Pass the country explicitly when you submit from your own server —
+  // see the note below.
+  countryCode: SmashsendCountryCode.ES,
+  // Credits the sharer when the visitor arrived via ?ref=
+  referralCode: req.query.ref as string,
+});
+
+// PENDING = the form uses double opt-in and we emailed a confirmation link.
+if (entry.status === 'PENDING') {
+  console.log('Tell them to check their inbox');
+}
+```
+
+> **Country codes.** SMASHSEND derives a respondent's country from the IP that
+> submits the form. That is right for a browser, but wrong when you submit from
+> your backend — there the IP is your datacenter, so every respondent would be
+> filed under the same country. Pass `countryCode` (ISO 3166-1 alpha-2, from the
+> `SmashsendCountryCode` enum) whenever you submit server-side. Invalid codes are
+> rejected by the API rather than stored.
+
+**Read a form's questions:**
+
+```typescript
+const { form } = await smashsend.forms.get('pk_abc123');
+
+form.config?.fields.forEach((field) => {
+  console.log(`${field.key} (${field.type}): ${field.label}`);
+});
+
+// Password-protected forms only return `config` with the right password
+const protectedForm = await smashsend.forms.get('pk_abc123', {
+  password: 'hunter2',
+});
+```
+
+**Referral status for one participant** (public — use the `publicId` returned by
+`submit()`):
+
+```typescript
+const { referralStatus } = await smashsend.forms.getReferralStatus(
+  'pk_abc123',
+  entry.publicId!
+);
+
+console.log(`#${referralStatus.position} of ${referralStatus.participantTotal}`);
+console.log(`Share link: ${referralStatus.shareUrl}`);
+console.log(`${referralStatus.points} points from ${referralStatus.referralCount} referrals`);
+```
+
+**Complete a referral task:**
+
+```typescript
+// AUTO tasks award points immediately; MANUAL tasks land as PENDING with the
+// proof until someone approves them in the dashboard.
+const { task } = await smashsend.forms.completeTask(
+  'pk_abc123',
+  entry.publicId!,
+  'task_follow_x',
+  { proof: { handle: '@jane' } }
+);
+
+console.log(`${task.status} (+${task.pointsAwarded} points)`);
+```
+
+**Email a returning participant their link:**
+
+```typescript
+await smashsend.forms.sendStatusLink('pk_abc123', 'jane@example.com');
+```
+
+**Leaderboard** — dual-mode. With the form's `publicKey` you get the masked
+public list; with the form `id` and your API key you get real emails and true
+ranks:
+
+```typescript
+const { leaderboard } = await smashsend.forms.getLeaderboard('frm_abc123', {
+  limit: 25,
+});
+
+leaderboard.items.forEach((row) => {
+  console.log(`#${row.rank} ${row.email ?? row.maskedEmail}: ${row.points} points`);
+});
+```
+
+**Position and points ledger** (customer API — requires an API key):
+
+```typescript
+// Look up by entry id or by email
+const { position } = await smashsend.forms.getEntryPosition(
+  'frm_abc123',
+  'jane@example.com'
+);
+
+// Every referral credit, task completion and manual adjustment
+const { rewards } = await smashsend.forms.listEntryRewards('frm_abc123', 'fen_123');
+
+rewards.items.forEach((reward) => {
+  console.log(`${reward.type} +${reward.points} (${reward.status})`);
+});
+```
+
+**Notes**
+
+- Submissions are deduplicated per (form, email): submitting the same email
+  twice returns the existing entry instead of creating a duplicate.
+- `position`, `peopleAhead` and `participantTotal` include any display offsets
+  configured on the form. `points` and `referralCount` are always the real
+  numbers.
+- Double opt-in confirmation is a redirect link in the confirmation email, so it
+  isn't exposed as an SDK method.
+
 ## Advanced Configuration
 
 **Custom Headers**

--- a/examples/forms-usage.ts
+++ b/examples/forms-usage.ts
@@ -1,0 +1,110 @@
+/**
+ * Forms API — hosted forms and referral waitlists.
+ *
+ * Run with: npx ts-node examples/forms-usage.ts
+ */
+import { SmashSend, SmashsendCountryCode } from '../src';
+
+const smashsend = new SmashSend(process.env.SMASHSEND_API_KEY || 'smashsend_xxxxxxxxxxxx');
+
+// The form's public key — the `/f/{publicKey}` segment of its hosted URL.
+const PUBLIC_KEY = 'pk_abc123';
+// The form's id — used by the API-key-authenticated endpoints.
+const FORM_ID = 'frm_abc123';
+
+async function readTheForm() {
+  const { form } = await smashsend.forms.get(PUBLIC_KEY);
+
+  console.log(`${form.displayName} (${form.status})`);
+  form.config?.fields.forEach((field) => {
+    console.log(`  ${field.key} (${field.type})${field.required ? ' *' : ''}: ${field.label}`);
+  });
+
+  if (form.referral?.isEnabled) {
+    console.log(`Referrals on: ${form.referral.pointsPerReferral} points per friend`);
+    form.referral.tasks.forEach((task) => {
+      console.log(`  task ${task.id}: ${task.label} (+${task.points}, ${task.approval})`);
+    });
+  }
+}
+
+async function submitServerSide() {
+  const { entry } = await smashsend.forms.submit(PUBLIC_KEY, {
+    email: 'jane@example.com',
+    answers: {
+      firstName: 'Jane',
+      company: 'Acme',
+    },
+    // IMPORTANT for server-side submissions: without this the country is
+    // resolved from the caller's IP, which here is your own server.
+    countryCode: SmashsendCountryCode.ES,
+    // Present when the visitor arrived through someone's invite link.
+    referralCode: 'ref_xyz',
+  });
+
+  console.log(`Entry ${entry.id} (${entry.status})`);
+
+  if (entry.status === 'PENDING') {
+    console.log('Double opt-in is on — we emailed them a confirmation link.');
+  }
+
+  return entry;
+}
+
+async function driveTheReferralLoop(publicId: string) {
+  const { referralStatus } = await smashsend.forms.getReferralStatus(PUBLIC_KEY, publicId);
+
+  console.log(`#${referralStatus.position} of ${referralStatus.participantTotal}`);
+  console.log(`${referralStatus.points} points, ${referralStatus.referralCount} referrals`);
+  console.log(`Share: ${referralStatus.shareUrl}`);
+
+  // Manual tasks need proof and stay PENDING until approved in the dashboard.
+  const { task } = await smashsend.forms.completeTask(PUBLIC_KEY, publicId, 'task_follow_x', {
+    proof: { handle: '@jane' },
+  });
+  console.log(`Task ${task.taskId}: ${task.status} (+${task.pointsAwarded})`);
+
+  // "Already signed up?" — email them their personal link.
+  await smashsend.forms.sendStatusLink(PUBLIC_KEY, 'jane@example.com');
+}
+
+async function readWithApiKey() {
+  // Real emails and true ranks (the public-key call returns masked emails).
+  const { leaderboard } = await smashsend.forms.getLeaderboard(FORM_ID, { limit: 10 });
+  leaderboard.items.forEach((row) => {
+    console.log(`#${row.rank} ${row.email ?? row.maskedEmail}: ${row.points} points`);
+  });
+
+  // Position lookup accepts an entry id or an email.
+  const { position } = await smashsend.forms.getEntryPosition(FORM_ID, 'jane@example.com');
+  console.log(`Position ${position.position} with ${position.points} points`);
+
+  // The full points ledger for one entry, newest first.
+  let cursor: string | undefined;
+  do {
+    const { rewards } = await smashsend.forms.listEntryRewards(FORM_ID, 'fen_123', {
+      limit: 50,
+      cursor,
+    });
+
+    rewards.items.forEach((reward) => {
+      console.log(`${reward.type} +${reward.points} (${reward.status}) ${reward.createdAt}`);
+    });
+
+    cursor = rewards.hasMore ? (rewards.cursor ?? undefined) : undefined;
+  } while (cursor);
+}
+
+async function main() {
+  await readTheForm();
+  const entry = await submitServerSide();
+  if (entry.publicId) {
+    await driveTheReferralLoop(entry.publicId);
+  }
+  await readWithApiKey();
+}
+
+main().catch((error) => {
+  console.error('Forms example failed:', error);
+  process.exit(1);
+});

--- a/examples/forms-usage.ts
+++ b/examples/forms-usage.ts
@@ -13,7 +13,7 @@ const PUBLIC_KEY = 'pk_abc123';
 const FORM_ID = 'frm_abc123';
 
 async function readTheForm() {
-  const { form } = await smashsend.forms.getByPublicKey(PUBLIC_KEY);
+  const { form } = await smashsend.forms.getPublicForm(PUBLIC_KEY);
 
   console.log(`${form.displayName} (${form.status})`);
   form.config?.fields.forEach((field) => {

--- a/examples/forms-usage.ts
+++ b/examples/forms-usage.ts
@@ -13,7 +13,7 @@ const PUBLIC_KEY = 'pk_abc123';
 const FORM_ID = 'frm_abc123';
 
 async function readTheForm() {
-  const { form } = await smashsend.forms.get(PUBLIC_KEY);
+  const { form } = await smashsend.forms.getByPublicKey(PUBLIC_KEY);
 
   console.log(`${form.displayName} (${form.status})`);
   form.config?.fields.forEach((field) => {

--- a/src/__tests__/forms.test.ts
+++ b/src/__tests__/forms.test.ts
@@ -1,0 +1,232 @@
+import { SmashSend } from '../index';
+import { SmashsendCountryCode } from '../interfaces/types';
+import { HttpClient } from '../utils/http-client';
+
+// Mock the HttpClient
+jest.mock('../utils/http-client');
+const MockedHttpClient = HttpClient as jest.MockedClass<typeof HttpClient>;
+
+describe('Forms API', () => {
+  let smashsend: SmashSend;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    smashsend = new SmashSend('test-api-key');
+    mockHttpClient = MockedHttpClient.mock.instances[0] as jest.Mocked<HttpClient>;
+  });
+
+  describe('get()', () => {
+    it('fetches a published form by public key', async () => {
+      const mockResponse = {
+        form: {
+          id: 'frm_123',
+          displayName: 'Waitlist',
+          publicKey: 'pk_abc',
+          status: 'PUBLISHED',
+          config: { version: 1, fields: [] },
+        },
+      };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.get('pk_abc');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
+        params: undefined,
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('passes the password for protected forms', async () => {
+      mockHttpClient.get.mockResolvedValue({ form: {} });
+
+      await smashsend.forms.get('pk_abc', { password: 'hunter2' });
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
+        params: { password: 'hunter2' },
+      });
+    });
+  });
+
+  describe('submit()', () => {
+    it('submits a response', async () => {
+      const mockResponse = {
+        success: true,
+        entry: { id: 'fen_1', publicId: 'pub_1', status: 'CONFIRMED' },
+      };
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.submit('pk_abc', {
+        email: 'jane@example.com',
+        answers: { firstName: 'Jane' },
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/forms/pk_abc/submit', {
+        email: 'jane@example.com',
+        answers: { firstName: 'Jane' },
+      });
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('forwards an explicit country code for server-side submissions', async () => {
+      mockHttpClient.post.mockResolvedValue({ success: true, entry: {} });
+
+      await smashsend.forms.submit('pk_abc', {
+        email: 'jane@example.com',
+        countryCode: SmashsendCountryCode.ES,
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/forms/pk_abc/submit', {
+        email: 'jane@example.com',
+        countryCode: 'ES',
+      });
+    });
+
+    it('forwards the referral code so the sharer gets credited', async () => {
+      mockHttpClient.post.mockResolvedValue({ success: true, entry: {} });
+
+      await smashsend.forms.submit('pk_abc', {
+        email: 'jane@example.com',
+        referralCode: 'ref_xyz',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/forms/pk_abc/submit', {
+        email: 'jane@example.com',
+        referralCode: 'ref_xyz',
+      });
+    });
+  });
+
+  describe('getReferralStatus()', () => {
+    it('reads a participant status by public id', async () => {
+      const mockResponse = {
+        referralStatus: {
+          entryId: 'fen_1',
+          status: 'CONFIRMED',
+          referralCode: 'ref_xyz',
+          shareUrl: 'https://smashsend.com/f/pk_abc?ref=ref_xyz',
+          points: 30,
+          referralCount: 3,
+          position: 12,
+          peopleAhead: 11,
+          participantTotal: 400,
+          tasks: [],
+        },
+      };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.getReferralStatus('pk_abc', 'pub_1');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/forms/pk_abc/entries/pub_1/referral-status'
+      );
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('completeTask()', () => {
+    it('submits proof for a manual task', async () => {
+      const mockResponse = {
+        task: { taskId: 'task_1', status: 'PENDING', pointsAwarded: 0 },
+      };
+      mockHttpClient.post.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.completeTask('pk_abc', 'pub_1', 'task_1', {
+        proof: { handle: '@jane' },
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/forms/pk_abc/entries/pub_1/tasks/task_1/complete',
+        { proof: { handle: '@jane' } }
+      );
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('sends an empty body when a task needs no proof', async () => {
+      mockHttpClient.post.mockResolvedValue({ task: {} });
+
+      await smashsend.forms.completeTask('pk_abc', 'pub_1', 'task_1');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/forms/pk_abc/entries/pub_1/tasks/task_1/complete',
+        {}
+      );
+    });
+  });
+
+  describe('sendStatusLink()', () => {
+    it('emails a participant their personal link', async () => {
+      mockHttpClient.post.mockResolvedValue({ sent: true });
+
+      await smashsend.forms.sendStatusLink('pk_abc', 'jane@example.com');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/forms/pk_abc/status-link', {
+        email: 'jane@example.com',
+      });
+    });
+  });
+
+  describe('getLeaderboard()', () => {
+    it('reads the leaderboard with a limit', async () => {
+      const mockResponse = {
+        leaderboard: {
+          items: [{ rank: 1, email: 'jane@example.com', points: 90, referralCount: 9 }],
+        },
+      };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.getLeaderboard('frm_123', { limit: 25 });
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/frm_123/leaderboard', {
+        params: { limit: 25 },
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+
+  describe('getEntryPosition()', () => {
+    it('looks a position up by entry id', async () => {
+      const mockResponse = {
+        position: { position: 12, points: 30, referralCount: 3, participantCount: 400 },
+      };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.getEntryPosition('frm_123', 'fen_1');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/frm_123/entries/fen_1/position');
+      expect(result).toEqual(mockResponse);
+    });
+
+    it('url-encodes an email lookup', async () => {
+      mockHttpClient.get.mockResolvedValue({ position: {} });
+
+      await smashsend.forms.getEntryPosition('frm_123', 'jane+test@example.com');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith(
+        '/forms/frm_123/entries/jane%2Btest%40example.com/position'
+      );
+    });
+  });
+
+  describe('listEntryRewards()', () => {
+    it('lists the points ledger for an entry', async () => {
+      const mockResponse = {
+        rewards: {
+          cursor: null,
+          hasMore: false,
+          items: [{ id: 'fep_1', type: 'REFERRAL', points: 10, status: 'APPROVED' }],
+        },
+      };
+      mockHttpClient.get.mockResolvedValue(mockResponse);
+
+      const result = await smashsend.forms.listEntryRewards('frm_123', 'fen_1', {
+        limit: 50,
+      });
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/frm_123/entries/fen_1/rewards', {
+        params: { limit: 50 },
+      });
+      expect(result).toEqual(mockResponse);
+    });
+  });
+});

--- a/src/__tests__/forms.test.ts
+++ b/src/__tests__/forms.test.ts
@@ -16,7 +16,7 @@ describe('Forms API', () => {
     mockHttpClient = MockedHttpClient.mock.instances[0] as jest.Mocked<HttpClient>;
   });
 
-  describe('get()', () => {
+  describe('getByPublicKey()', () => {
     it('fetches a published form by public key', async () => {
       const mockResponse = {
         form: {
@@ -29,7 +29,7 @@ describe('Forms API', () => {
       };
       mockHttpClient.get.mockResolvedValue(mockResponse);
 
-      const result = await smashsend.forms.get('pk_abc');
+      const result = await smashsend.forms.getByPublicKey('pk_abc');
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
         params: undefined,
@@ -40,7 +40,7 @@ describe('Forms API', () => {
     it('passes the password for protected forms', async () => {
       mockHttpClient.get.mockResolvedValue({ form: {} });
 
-      await smashsend.forms.get('pk_abc', { password: 'hunter2' });
+      await smashsend.forms.getByPublicKey('pk_abc', { password: 'hunter2' });
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
         params: { password: 'hunter2' },

--- a/src/__tests__/forms.test.ts
+++ b/src/__tests__/forms.test.ts
@@ -16,7 +16,7 @@ describe('Forms API', () => {
     mockHttpClient = MockedHttpClient.mock.instances[0] as jest.Mocked<HttpClient>;
   });
 
-  describe('getByPublicKey()', () => {
+  describe('getPublicForm()', () => {
     it('fetches a published form by public key', async () => {
       const mockResponse = {
         form: {
@@ -29,7 +29,7 @@ describe('Forms API', () => {
       };
       mockHttpClient.get.mockResolvedValue(mockResponse);
 
-      const result = await smashsend.forms.getByPublicKey('pk_abc');
+      const result = await smashsend.forms.getPublicForm('pk_abc');
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
         params: undefined,
@@ -40,7 +40,7 @@ describe('Forms API', () => {
     it('passes the password for protected forms', async () => {
       mockHttpClient.get.mockResolvedValue({ form: {} });
 
-      await smashsend.forms.getByPublicKey('pk_abc', { password: 'hunter2' });
+      await smashsend.forms.getPublicForm('pk_abc', { password: 'hunter2' });
 
       expect(mockHttpClient.get).toHaveBeenCalledWith('/forms/pk_abc', {
         params: { password: 'hunter2' },

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -23,25 +23,30 @@ export class Forms {
   }
 
   /**
-   * Get a published form by its public key.
+   * Get a published form by its **public key** (not its id).
    *
-   * Public endpoint — safe to call from a browser. Only PUBLISHED forms are
-   * returned. For a password-protected form the questions (`config`) are only
-   * included when the correct password is supplied.
+   * Named for the identifier it takes: `forms.get(formId)` is reserved for the
+   * workspace-scoped lookup, which the API does not expose yet.
+   *
+   * Only PUBLISHED forms are returned. For a password-protected form the
+   * questions (`config`) are only included when the correct password is
+   * supplied. If the form restricts allowed domains, browser calls from a
+   * domain that isn't on the list are rejected; a call carrying your API key
+   * is never blocked.
    *
    * @param publicKey The form's public key (the `/f/{publicKey}` segment)
    * @param options Optional password for protected forms
    *
    * @example
    * ```typescript
-   * const { form } = await smashsend.forms.get('pk_abc123');
+   * const { form } = await smashsend.forms.getByPublicKey('pk_abc123');
    *
    * form.config?.fields.forEach(field => {
    *   console.log(`${field.key}: ${field.label}`);
    * });
    * ```
    */
-  async get(publicKey: string, options?: FormGetOptions): Promise<FormGetResponse> {
+  async getByPublicKey(publicKey: string, options?: FormGetOptions): Promise<FormGetResponse> {
     return await this.httpClient.get<FormGetResponse>(`/forms/${publicKey}`, {
       params: options?.password ? { password: options.password } : undefined,
     });
@@ -57,6 +62,10 @@ export class Forms {
    * Pass `countryCode` when you submit from your own backend — SMASHSEND
    * otherwise derives the country from the caller's IP, which server-side is
    * your datacenter and not the respondent.
+   *
+   * A form can restrict which domains may submit it. That check is skipped for
+   * calls carrying your API key, since it keys off the browser's `Origin`
+   * header, which a server-side caller doesn't send.
    *
    * @param publicKey The form's public key
    * @param options The response to record

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -23,10 +23,11 @@ export class Forms {
   }
 
   /**
-   * Get a published form by its **public key** (not its id).
+   * Get the public view of a published form — the questions a respondent sees,
+   * looked up by the form's public key.
    *
-   * Named for the identifier it takes: `forms.get(formId)` is reserved for the
-   * workspace-scoped lookup, which the API does not expose yet.
+   * Named for what it returns, leaving `forms.get(formId)` free for the
+   * workspace-scoped lookup once the API exposes one.
    *
    * Only PUBLISHED forms are returned. For a password-protected form the
    * questions (`config`) are only included when the correct password is
@@ -39,14 +40,14 @@ export class Forms {
    *
    * @example
    * ```typescript
-   * const { form } = await smashsend.forms.getByPublicKey('pk_abc123');
+   * const { form } = await smashsend.forms.getPublicForm('pk_abc123');
    *
    * form.config?.fields.forEach(field => {
    *   console.log(`${field.key}: ${field.label}`);
    * });
    * ```
    */
-  async getByPublicKey(publicKey: string, options?: FormGetOptions): Promise<FormGetResponse> {
+  async getPublicForm(publicKey: string, options?: FormGetOptions): Promise<FormGetResponse> {
     return await this.httpClient.get<FormGetResponse>(`/forms/${publicKey}`, {
       params: options?.password ? { password: options.password } : undefined,
     });

--- a/src/api/forms.ts
+++ b/src/api/forms.ts
@@ -1,0 +1,264 @@
+import { HttpClient } from '../utils/http-client';
+import {
+  FormCompleteTaskOptions,
+  FormEntryPositionResponse,
+  FormGetOptions,
+  FormGetResponse,
+  FormLeaderboardOptions,
+  FormLeaderboardResponse,
+  FormReferralStatusResponse,
+  FormReferralTaskStatus,
+  FormRewardListOptions,
+  FormRewardListResponse,
+  FormStatusLinkResponse,
+  FormSubmitOptions,
+  FormSubmitResponse,
+} from '../interfaces/forms';
+
+export class Forms {
+  private httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Get a published form by its public key.
+   *
+   * Public endpoint — safe to call from a browser. Only PUBLISHED forms are
+   * returned. For a password-protected form the questions (`config`) are only
+   * included when the correct password is supplied.
+   *
+   * @param publicKey The form's public key (the `/f/{publicKey}` segment)
+   * @param options Optional password for protected forms
+   *
+   * @example
+   * ```typescript
+   * const { form } = await smashsend.forms.get('pk_abc123');
+   *
+   * form.config?.fields.forEach(field => {
+   *   console.log(`${field.key}: ${field.label}`);
+   * });
+   * ```
+   */
+  async get(publicKey: string, options?: FormGetOptions): Promise<FormGetResponse> {
+    return await this.httpClient.get<FormGetResponse>(`/forms/${publicKey}`, {
+      params: options?.password ? { password: options.password } : undefined,
+    });
+  }
+
+  /**
+   * Submit a response to a form.
+   *
+   * Public endpoint. Submissions are deduplicated per (form, email): sending
+   * the same email twice returns the existing entry rather than creating a
+   * second one.
+   *
+   * Pass `countryCode` when you submit from your own backend — SMASHSEND
+   * otherwise derives the country from the caller's IP, which server-side is
+   * your datacenter and not the respondent.
+   *
+   * @param publicKey The form's public key
+   * @param options The response to record
+   *
+   * @example
+   * ```typescript
+   * import { SmashsendCountryCode } from '@smashsend/node';
+   *
+   * const { entry } = await smashsend.forms.submit('pk_abc123', {
+   *   email: 'jane@example.com',
+   *   answers: { firstName: 'Jane', company: 'Acme' },
+   *   countryCode: SmashsendCountryCode.ES,
+   *   referralCode: req.query.ref,
+   * });
+   *
+   * // PENDING means the form uses double opt-in and we emailed a confirm link.
+   * if (entry.status === 'PENDING') {
+   *   console.log('Ask them to check their inbox');
+   * }
+   * ```
+   */
+  async submit(publicKey: string, options: FormSubmitOptions): Promise<FormSubmitResponse> {
+    return await this.httpClient.post<FormSubmitResponse>(`/forms/${publicKey}/submit`, options);
+  }
+
+  /**
+   * Get a participant's own referral progress (position, points, share link,
+   * task states).
+   *
+   * Public endpoint, keyed by the entry's `publicId` — the value returned by
+   * {@link submit}. Position and participant totals include the form's display
+   * offsets; points and referral counts are always real.
+   *
+   * @param publicKey The form's public key
+   * @param publicId The entry's public id
+   *
+   * @example
+   * ```typescript
+   * const { referralStatus } = await smashsend.forms.getReferralStatus(
+   *   'pk_abc123',
+   *   entry.publicId!
+   * );
+   *
+   * console.log(`#${referralStatus.position} — share ${referralStatus.shareUrl}`);
+   * ```
+   */
+  async getReferralStatus(
+    publicKey: string,
+    publicId: string
+  ): Promise<FormReferralStatusResponse> {
+    return await this.httpClient.get<FormReferralStatusResponse>(
+      `/forms/${publicKey}/entries/${publicId}/referral-status`
+    );
+  }
+
+  /**
+   * Mark a referral task as completed by a participant.
+   *
+   * Public endpoint. AUTO tasks award their points immediately; MANUAL tasks
+   * land as PENDING with the supplied proof until someone approves them in the
+   * dashboard.
+   *
+   * @param publicKey The form's public key
+   * @param publicId The entry's public id
+   * @param taskId The task id from the form's referral settings
+   * @param options Proof for manual tasks (post URL or handle)
+   *
+   * @example
+   * ```typescript
+   * const { task } = await smashsend.forms.completeTask(
+   *   'pk_abc123',
+   *   entry.publicId!,
+   *   'task_follow_x',
+   *   { proof: { handle: '@jane' } }
+   * );
+   *
+   * console.log(`${task.status} (+${task.pointsAwarded} points)`);
+   * ```
+   */
+  async completeTask(
+    publicKey: string,
+    publicId: string,
+    taskId: string,
+    options?: FormCompleteTaskOptions
+  ): Promise<{ task: FormReferralTaskStatus & { pointsAwarded: number } }> {
+    return await this.httpClient.post<{
+      task: FormReferralTaskStatus & { pointsAwarded: number };
+    }>(`/forms/${publicKey}/entries/${publicId}/tasks/${taskId}/complete`, options ?? {});
+  }
+
+  /**
+   * Email a participant their personal referral link.
+   *
+   * Public endpoint — the "already signed up?" flow. Always resolves the same
+   * way whether or not the email is on the list, so it can't be used to probe
+   * membership.
+   *
+   * @param publicKey The form's public key
+   * @param email The participant's email
+   *
+   * @example
+   * ```typescript
+   * await smashsend.forms.sendStatusLink('pk_abc123', 'jane@example.com');
+   * ```
+   */
+  async sendStatusLink(publicKey: string, email: string): Promise<FormStatusLinkResponse> {
+    return await this.httpClient.post<FormStatusLinkResponse>(`/forms/${publicKey}/status-link`, {
+      email,
+    });
+  }
+
+  /**
+   * Get a form's leaderboard.
+   *
+   * Dual-mode: called with the form's **public key** it returns the masked
+   * public leaderboard (as the hosted page shows it). Called with the form's
+   * **id** and a workspace API key it returns real emails and true ranks.
+   *
+   * @param formIdOrPublicKey The form id (API key) or public key (guest)
+   * @param options `limit` applies to the customer-API branch only
+   *
+   * @example
+   * ```typescript
+   * const { leaderboard } = await smashsend.forms.getLeaderboard('frm_abc123', {
+   *   limit: 25,
+   * });
+   *
+   * leaderboard.items.forEach(row => {
+   *   console.log(`#${row.rank} ${row.email ?? row.maskedEmail}: ${row.points}`);
+   * });
+   * ```
+   */
+  async getLeaderboard(
+    formIdOrPublicKey: string,
+    options?: FormLeaderboardOptions
+  ): Promise<FormLeaderboardResponse> {
+    return await this.httpClient.get<FormLeaderboardResponse>(
+      `/forms/${formIdOrPublicKey}/leaderboard`,
+      { params: options }
+    );
+  }
+
+  /**
+   * Get one entry's leaderboard position, looked up by entry id **or** email.
+   *
+   * Customer API — requires a workspace API key.
+   *
+   * @param formId The form id
+   * @param entryIdOrEmail The entry id or the participant's email
+   *
+   * @example
+   * ```typescript
+   * const { position } = await smashsend.forms.getEntryPosition(
+   *   'frm_abc123',
+   *   'jane@example.com'
+   * );
+   *
+   * console.log(`#${position.position} of ${position.participantCount}`);
+   * ```
+   */
+  async getEntryPosition(
+    formId: string,
+    entryIdOrEmail: string
+  ): Promise<FormEntryPositionResponse> {
+    return await this.httpClient.get<FormEntryPositionResponse>(
+      `/forms/${formId}/entries/${encodeURIComponent(entryIdOrEmail)}/position`
+    );
+  }
+
+  /**
+   * List the points ledger for one entry — every referral credit, task
+   * completion and manual adjustment, with its review status.
+   *
+   * Customer API — requires a workspace API key.
+   *
+   * @param formId The form id
+   * @param entryId The entry id
+   * @param params Pagination parameters
+   *
+   * @example
+   * ```typescript
+   * const { rewards } = await smashsend.forms.listEntryRewards('frm_abc', 'fen_123');
+   *
+   * rewards.items.forEach(reward => {
+   *   console.log(`${reward.type} +${reward.points} (${reward.status})`);
+   * });
+   *
+   * if (rewards.hasMore) {
+   *   const next = await smashsend.forms.listEntryRewards('frm_abc', 'fen_123', {
+   *     cursor: rewards.cursor!,
+   *   });
+   * }
+   * ```
+   */
+  async listEntryRewards(
+    formId: string,
+    entryId: string,
+    params?: FormRewardListOptions
+  ): Promise<FormRewardListResponse> {
+    return await this.httpClient.get<FormRewardListResponse>(
+      `/forms/${formId}/entries/${entryId}/rewards`,
+      { params }
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { Webhooks } from './api/webhooks';
 import { ApiKeys } from './api/api-keys';
 import { Domains } from './api/domains';
 import { Events } from './api/events';
+import { Forms } from './api/forms';
 import { HttpClient } from './utils/http-client';
 import { SmashSendClientOptions } from './interfaces/types';
 import {
@@ -46,6 +47,11 @@ export class SmashSend {
    */
   public readonly events: Events;
 
+  /**
+   * The Forms API resource (hosted forms + referral waitlists)
+   */
+  public readonly forms: Forms;
+
   private httpClient: HttpClient;
 
   /**
@@ -76,6 +82,7 @@ export class SmashSend {
     this.domains = new Domains(this.httpClient);
     this.emails = new Emails(this.httpClient);
     this.events = new Events(this.httpClient);
+    this.forms = new Forms(this.httpClient);
     this.webhooks = new Webhooks(this.httpClient);
   }
 
@@ -161,6 +168,42 @@ export type {
   BatchEventResponse,
   EventTrackingOptions,
 } from './interfaces/types';
+
+// Export forms types
+export type {
+  SmashsendForm,
+  FormStatus,
+  FormField,
+  FormFieldType,
+  FormFieldOption,
+  FormConfig,
+  FormGetOptions,
+  FormGetResponse,
+  FormEntryStatus,
+  FormSubmitOptions,
+  FormSubmitResponse,
+  FormPublicReferralSettings,
+  FormReferralTask,
+  FormReferralTaskType,
+  FormReferralTaskApproval,
+  FormReferralTaskProofType,
+  FormReferralStatus,
+  FormReferralStatusResponse,
+  FormReferralTaskStatus,
+  FormTaskStatus,
+  FormCompleteTaskOptions,
+  FormStatusLinkResponse,
+  FormEntryPosition,
+  FormEntryPositionResponse,
+  FormReward,
+  FormRewardType,
+  FormRewardStatus,
+  FormRewardListOptions,
+  FormRewardListResponse,
+  FormLeaderboardEntry,
+  FormLeaderboardOptions,
+  FormLeaderboardResponse,
+} from './interfaces/forms';
 
 // Export domain types
 export type {

--- a/src/interfaces/forms.ts
+++ b/src/interfaces/forms.ts
@@ -1,0 +1,256 @@
+import { SmashsendCountryCode } from './types';
+
+/**
+ * The Forms API covers SMASHSEND's hosted/headless forms and the referral
+ * ("viral waitlist") system built on top of them.
+ *
+ * Two kinds of endpoint live here:
+ *
+ * - **Public** (`publicKey`): reading a published form, submitting a response,
+ *   confirming double opt-in, and the participant's own referral status. These
+ *   need no API key — they are the endpoints a browser or your server calls on
+ *   behalf of the person filling the form.
+ * - **Customer API** (`formId`, API key): entry position, the rewards ledger
+ *   and the unmasked leaderboard. These require a workspace API key.
+ */
+
+export type FormStatus = 'DRAFT' | 'PUBLISHED' | 'ARCHIVED';
+
+export type FormFieldType =
+  | 'email'
+  | 'text'
+  | 'textarea'
+  | 'number'
+  | 'select'
+  | 'multiselect'
+  | 'checkbox'
+  | 'radio'
+  | 'date'
+  | 'url'
+  | 'phone';
+
+export interface FormFieldOption {
+  id: string;
+  label: string;
+  value: string;
+}
+
+export interface FormField {
+  key: string;
+  type: FormFieldType;
+  label: string;
+  placeholder?: string | null;
+  required?: boolean;
+  options?: FormFieldOption[];
+}
+
+export type FormReferralTaskType = 'VISIT_LINK' | 'TWITTER_FOLLOW' | 'JOIN_NEWSLETTER';
+
+export type FormReferralTaskApproval = 'AUTO' | 'MANUAL';
+
+export type FormReferralTaskProofType = 'NONE' | 'POST_URL' | 'HANDLE';
+
+/** A bonus action a participant can complete for extra points. */
+export interface FormReferralTask {
+  id: string;
+  type: FormReferralTaskType;
+  label: string;
+  url?: string | null;
+  points: number;
+  approval: FormReferralTaskApproval;
+  proofType: FormReferralTaskProofType;
+}
+
+/** Referral settings as exposed publicly (display offsets are never included). */
+export interface FormPublicReferralSettings {
+  isEnabled: boolean;
+  pointsPerReferral: number;
+  shareText: string;
+  showLeaderboard: boolean;
+  leaderboardSize: number;
+  tasks: FormReferralTask[];
+}
+
+export interface FormConfig {
+  version: number;
+  fields: FormField[];
+  [key: string]: any;
+}
+
+/** A published form as returned by the public endpoint. */
+export interface SmashsendForm {
+  id: string;
+  displayName: string | null;
+  publicKey: string;
+  status: FormStatus;
+  config: FormConfig | null;
+  /** True when the form needs a password before its questions are returned. */
+  passwordProtected?: boolean;
+  /** Present only when referrals are enabled on the form. */
+  referral?: FormPublicReferralSettings;
+}
+
+export interface FormGetOptions {
+  /** Password for a password-protected form. Without it, `config` is withheld. */
+  password?: string;
+}
+
+export interface FormGetResponse {
+  form: SmashsendForm;
+}
+
+export type FormEntryStatus = 'PENDING' | 'CONFIRMED' | 'UNSUBSCRIBED' | 'BANNED';
+
+export interface FormSubmitOptions {
+  /** The respondent's email. The only required field. */
+  email: string;
+  /** Answers keyed by the form field's `key`. */
+  answers?: Record<string, any>;
+  /**
+   * ISO 3166-1 alpha-2 country for the respondent.
+   *
+   * SMASHSEND otherwise derives the country from the caller's IP at submit
+   * time. When you submit from your own backend that IP is your server, so
+   * every respondent would be filed under your datacenter's country — pass
+   * this explicitly for server-side submissions.
+   */
+  countryCode?: SmashsendCountryCode;
+  /** Password for a password-protected form. */
+  password?: string;
+  /** Captcha token, when the form has captcha enabled. */
+  captchaToken?: string;
+  /** The `?ref=` code from a sharer's invite link, to credit the referral. */
+  referralCode?: string;
+}
+
+export interface FormSubmitResponse {
+  success: boolean;
+  entry: {
+    id: string;
+    /** Opaque id used on participant-facing referral endpoints. */
+    publicId: string | null;
+    /**
+     * `PENDING` when the form uses double opt-in (the participant still has to
+     * click the emailed link), `CONFIRMED` otherwise.
+     */
+    status: FormEntryStatus;
+  };
+}
+
+export type FormTaskStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'REVOKED';
+
+export interface FormReferralTaskStatus {
+  taskId: string;
+  status: FormTaskStatus;
+}
+
+/**
+ * A participant's own referral progress. `position`, `peopleAhead` and
+ * `participantTotal` already have the form's display offsets applied; `points`
+ * and `referralCount` are always real.
+ */
+export interface FormReferralStatus {
+  entryId: string;
+  status: FormEntryStatus;
+  referralCode: string;
+  shareUrl: string;
+  points: number;
+  referralCount: number;
+  position: number | null;
+  peopleAhead: number | null;
+  participantTotal: number;
+  tasks: FormReferralTaskStatus[];
+}
+
+export interface FormReferralStatusResponse {
+  referralStatus: FormReferralStatus;
+}
+
+export interface FormCompleteTaskOptions {
+  /** Proof for a manual task: the post URL or the handle, per `proofType`. */
+  proof?: {
+    url?: string;
+    handle?: string;
+  };
+}
+
+export interface FormStatusLinkResponse {
+  success: boolean;
+}
+
+/**
+ * Entry position from the customer API. `position` and `participantCount`
+ * include the form's display offsets; `points` and `referralCount` are real.
+ */
+export interface FormEntryPosition {
+  position: number | null;
+  points: number;
+  referralCount: number;
+  participantCount: number;
+}
+
+export interface FormEntryPositionResponse {
+  position: FormEntryPosition;
+}
+
+export type FormRewardType = 'REFERRAL' | 'TASK' | 'ADJUSTMENT';
+
+export type FormRewardStatus = 'PENDING' | 'APPROVED' | 'REJECTED' | 'REVOKED';
+
+/** One row of the append-only points ledger. */
+export interface FormReward {
+  id: string;
+  workspaceId: string;
+  formId: string;
+  entryId: string;
+  entryEmail: string | null;
+  type: FormRewardType;
+  /** Set for TASK rows: the id of the task inside the form's referral settings. */
+  taskId: string | null;
+  points: number;
+  status: FormRewardStatus;
+  proof: { url?: string; handle?: string } | null;
+  /** Idempotency key: `ref:{referredEntryId}` or `task:{taskId}`. */
+  dedupKey: string;
+  metadata: Record<string, any> | null;
+  reviewedAt: string | null;
+  reviewedByUid: string | null;
+  createdAt: string;
+  updatedAt: string | null;
+}
+
+export interface FormRewardListOptions {
+  limit?: number;
+  cursor?: string;
+}
+
+export interface FormRewardListResponse {
+  rewards: {
+    cursor: string | null;
+    hasMore: boolean;
+    items: FormReward[];
+  };
+}
+
+export interface FormLeaderboardEntry {
+  rank: number;
+  /** Present on the guest (public key) branch, e.g. `jo•••@example.com`. */
+  maskedEmail?: string;
+  /** Present on the customer-API (form id + API key) branch. */
+  email?: string;
+  firstName?: string | null;
+  points: number;
+  referralCount: number;
+}
+
+export interface FormLeaderboardOptions {
+  /** Customer API only; the public branch uses the form's `leaderboardSize`. */
+  limit?: number;
+}
+
+export interface FormLeaderboardResponse {
+  leaderboard: {
+    items: FormLeaderboardEntry[];
+    [key: string]: any;
+  };
+}


### PR DESCRIPTION
Adds a `forms` resource to the SDK. Until now the SDK had no forms support at all — contacts, events, groups, emails, transactional, domains, webhooks and api-keys only.

## What's in it

| Method | Auth | Endpoint |
| --- | --- | --- |
| `forms.get(publicKey, { password? })` | public | `GET /v1/forms/{publicKey}` |
| `forms.submit(publicKey, options)` | public | `POST /v1/forms/{publicKey}/submit` |
| `forms.getReferralStatus(publicKey, publicId)` | public | `GET /v1/forms/{publicKey}/entries/{publicId}/referral-status` |
| `forms.completeTask(publicKey, publicId, taskId, { proof? })` | public | `POST .../tasks/{taskId}/complete` |
| `forms.sendStatusLink(publicKey, email)` | public | `POST /v1/forms/{publicKey}/status-link` |
| `forms.getLeaderboard(formIdOrPublicKey, { limit? })` | dual | `GET /v1/forms/{key}/leaderboard` |
| `forms.getEntryPosition(formId, entryIdOrEmail)` | API key | `GET /v1/forms/{formId}/entries/{idOrEmail}/position` |
| `forms.listEntryRewards(formId, entryId, { limit?, cursor? })` | API key | `GET /v1/forms/{formId}/entries/{entryId}/rewards` |

## Country codes

`submit()` accepts an optional `countryCode`, typed with the existing `SmashsendCountryCode` enum.

This is the point of the change for server-side users: the API derives a respondent's country from the IP that submits the form. That's correct for a browser, but when you submit from your backend the IP is your datacenter — so every respondent lands under the same country. Passing `countryCode` fixes that, and invalid codes are rejected by the API rather than silently stored.

> [!IMPORTANT]
> **Needs the backend change first.** `countryCode` is only accepted once the matching smashsend change ships (ISO-validated on `POST /v1/forms/{publicKey}/submit`, taking precedence over the geo-IP lookup). Every other method here works against production today. Hold the release until that's deployed, or the field is silently stripped by request validation.

## Notes

- Double opt-in confirmation is intentionally **not** exposed: that endpoint is a `GET` that 302s, meant for the link inside the confirmation email.
- `position` / `peopleAhead` / `participantTotal` carry the form's display offsets; `points` and `referralCount` are always real. Documented on the types.
- `getEntryPosition` URL-encodes the identifier so email lookups with `+` work.

## Verification

- `npx tsc --noEmit` clean
- 54/54 tests pass (13 new), 100% statement/branch/function coverage of `src/api/forms.ts`
- README section, `examples/forms-usage.ts`, CHANGELOG entry under Unreleased