### PR TITLE
feat: add Broadcasts API to SDK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Broadcasts API**: `smashsend.broadcasts` for programmatic marketing broadcasts
+  - `create()`, `list()`, `get()`, `schedule()`, `cancel()`, `sendTest()`
+  - Requires the Email API add-on, a verified workspace and the early-access flag
+  - Docs: https://smashsend.com/docs/api/broadcasts
+
+### Fixed
+
+- `VERSION` in `src/constants.ts` was pinned at `0.2.5` while the package published as `1.19.0`, so every request sent a wrong `User-Agent`. Now synced.
+
+### Added
+
 - **Forms API**: `smashsend.forms.*` — hosted forms and the referral/waitlist system
   - `forms.getPublicForm()` — read a published form's questions (supports password-protected forms)
   - `forms.submit()` — submit a response, with `countryCode` so server-side submissions

--- a/README.md
+++ b/README.md
@@ -725,6 +725,35 @@ await smashsend.contacts.update(contactId, {
 
 This is useful for webhooks or event-driven updates where you only know what changed.
 
+## Broadcasts API
+
+Create and schedule marketing broadcasts from your own pipeline. You send tested
+raw HTML; SMASHSEND handles audience resolution, tracking, unsubscribe
+compliance and delivery pacing. [Full docs](https://smashsend.com/docs/api/broadcasts)
+
+> Requires the Email API add-on, a verified workspace, and the early-access flag
+> on your workspace.
+
+```typescript
+const { broadcast } = await smashsend.broadcasts.create({
+  name: 'Weekly newsletter #42',
+  subject: 'This week: {{firstName}}, the new roadmap is live',
+  fromEmail: 'news@yourdomain.com',
+  html: '<html><body><h1>Hello {{firstName}}</h1></body></html>',
+  audience: { all: true },
+  settings: { trackOpens: true, trackClicks: true },
+});
+
+// Always send yourself a test first
+await smashsend.broadcasts.sendTest(broadcast.id, {
+  emails: ['you@yourcompany.com'],
+});
+
+await smashsend.broadcasts.schedule(broadcast.id, {
+  sendAt: '2026-08-10T09:00:00.000Z',
+});
+```
+
 ## TypeScript Support
 
 - Built **in TypeScript**

--- a/src/__tests__/broadcasts.test.ts
+++ b/src/__tests__/broadcasts.test.ts
@@ -1,0 +1,120 @@
+import { SmashSend } from '../index';
+import { HttpClient } from '../utils/http-client';
+
+jest.mock('../utils/http-client');
+const MockedHttpClient = HttpClient as jest.MockedClass<typeof HttpClient>;
+
+describe('Broadcasts API', () => {
+  let smashsend: SmashSend;
+  let mockHttpClient: jest.Mocked<HttpClient>;
+
+  const broadcast = {
+    id: 'bcs_123',
+    subject: 'Weekly newsletter',
+    status: 'DRAFT',
+    createdAt: '2026-08-01T10:12:00.000Z',
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    smashsend = new SmashSend('test-api-key');
+    mockHttpClient = MockedHttpClient.mock.instances[0] as jest.Mocked<HttpClient>;
+  });
+
+  describe('create() method', () => {
+    it('should create a draft broadcast', async () => {
+      mockHttpClient.post.mockResolvedValue({ broadcast });
+
+      const payload = {
+        subject: 'Weekly newsletter',
+        fromEmail: 'news@yourdomain.com',
+        html: '<html><body><h1>Hi</h1></body></html>',
+        audience: { all: true },
+      };
+
+      const result = await smashsend.broadcasts.create(payload);
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith('/broadcasts', payload);
+      expect(result.broadcast.id).toBe('bcs_123');
+    });
+  });
+
+  describe('list() method', () => {
+    it('should list broadcasts with params', async () => {
+      mockHttpClient.get.mockResolvedValue({
+        broadcasts: { cursor: null, hasMore: false, items: [broadcast] },
+      });
+
+      const result = await smashsend.broadcasts.list({ limit: 10 });
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/broadcasts', {
+        params: { limit: 10 },
+      });
+      expect(result.broadcasts.items).toHaveLength(1);
+    });
+  });
+
+  describe('get() method', () => {
+    it('should fetch a single broadcast', async () => {
+      mockHttpClient.get.mockResolvedValue({ broadcast });
+
+      await smashsend.broadcasts.get('bcs_123');
+
+      expect(mockHttpClient.get).toHaveBeenCalledWith('/broadcasts/bcs_123');
+    });
+  });
+
+  describe('schedule() method', () => {
+    it('should schedule a broadcast with sendAt', async () => {
+      mockHttpClient.post.mockResolvedValue({ broadcast });
+
+      await smashsend.broadcasts.schedule('bcs_123', {
+        sendAt: '2026-08-10T09:00:00.000Z',
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/broadcasts/bcs_123/schedule',
+        { sendAt: '2026-08-10T09:00:00.000Z' }
+      );
+    });
+
+    it('should post an empty body when no options are given', async () => {
+      mockHttpClient.post.mockResolvedValue({ broadcast });
+
+      await smashsend.broadcasts.schedule('bcs_123');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/broadcasts/bcs_123/schedule',
+        {}
+      );
+    });
+  });
+
+  describe('cancel() method', () => {
+    it('should cancel a scheduled broadcast', async () => {
+      mockHttpClient.post.mockResolvedValue({ broadcast });
+
+      await smashsend.broadcasts.cancel('bcs_123');
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/broadcasts/bcs_123/cancel',
+        {}
+      );
+    });
+  });
+
+  describe('sendTest() method', () => {
+    it('should send a test broadcast', async () => {
+      mockHttpClient.post.mockResolvedValue({ broadcast });
+
+      await smashsend.broadcasts.sendTest('bcs_123', {
+        emails: ['you@yourcompany.com'],
+      });
+
+      expect(mockHttpClient.post).toHaveBeenCalledWith(
+        '/broadcasts/bcs_123/test',
+        { emails: ['you@yourcompany.com'] }
+      );
+    });
+  });
+});

--- a/src/api/broadcasts.ts
+++ b/src/api/broadcasts.ts
@@ -1,0 +1,120 @@
+import { HttpClient } from '../utils/http-client';
+import {
+  BroadcastCreateOptions,
+  BroadcastListOptions,
+  BroadcastListResponse,
+  BroadcastResponse,
+  BroadcastScheduleOptions,
+  BroadcastTestOptions,
+} from '../interfaces/broadcasts';
+
+export class Broadcasts {
+  private httpClient: HttpClient;
+
+  constructor(httpClient: HttpClient) {
+    this.httpClient = httpClient;
+  }
+
+  /**
+   * Create a draft broadcast from raw HTML.
+   *
+   * The HTML is stored exactly as sent; tracking links and required footers are
+   * applied when the broadcast is scheduled.
+   *
+   * @param data Broadcast creation options
+   * @returns The created broadcast
+   *
+   * @example
+   * ```typescript
+   * const { broadcast } = await smashsend.broadcasts.create({
+   *   name: 'Weekly newsletter #42',
+   *   subject: 'This week: {{firstName}}, the new roadmap is live',
+   *   fromEmail: 'news@yourdomain.com',
+   *   html: '<html><body><h1>Hello {{firstName}}</h1></body></html>',
+   *   audience: { all: true },
+   * });
+   *
+   * console.log(`Draft created: ${broadcast.id}`);
+   * ```
+   */
+  async create(data: BroadcastCreateOptions): Promise<BroadcastResponse> {
+    return await this.httpClient.post<BroadcastResponse>('/broadcasts', data);
+  }
+
+  /**
+   * List broadcasts, optionally filtered by status.
+   *
+   * @example
+   * ```typescript
+   * const { broadcasts } = await smashsend.broadcasts.list({ limit: 10 });
+   * broadcasts.items.forEach((b) => console.log(b.subject, b.status));
+   * ```
+   */
+  async list(params?: BroadcastListOptions): Promise<BroadcastListResponse> {
+    return await this.httpClient.get<BroadcastListResponse>('/broadcasts', {
+      params,
+    });
+  }
+
+  /**
+   * Get a single broadcast by ID.
+   */
+  async get(broadcastId: string): Promise<BroadcastResponse> {
+    return await this.httpClient.get<BroadcastResponse>(
+      `/broadcasts/${encodeURIComponent(broadcastId)}`
+    );
+  }
+
+  /**
+   * Schedule a broadcast for delivery.
+   *
+   * @example
+   * ```typescript
+   * await smashsend.broadcasts.schedule('bcs_123', {
+   *   sendAt: '2026-08-10T09:00:00.000Z',
+   * });
+   * ```
+   */
+  async schedule(
+    broadcastId: string,
+    data?: BroadcastScheduleOptions
+  ): Promise<BroadcastResponse> {
+    return await this.httpClient.post<BroadcastResponse>(
+      `/broadcasts/${encodeURIComponent(broadcastId)}/schedule`,
+      data ?? {}
+    );
+  }
+
+  /**
+   * Cancel a scheduled broadcast.
+   */
+  async cancel(broadcastId: string): Promise<BroadcastResponse> {
+    return await this.httpClient.post<BroadcastResponse>(
+      `/broadcasts/${encodeURIComponent(broadcastId)}/cancel`,
+      {}
+    );
+  }
+
+  /**
+   * Send a test copy of a broadcast to workspace members.
+   *
+   * Recipients must be members of your workspace. The email is sent with a
+   * [TEST] subject prefix.
+   *
+   * @example
+   * ```typescript
+   * await smashsend.broadcasts.sendTest('bcs_123', {
+   *   emails: ['you@yourcompany.com'],
+   * });
+   * ```
+   */
+  async sendTest(
+    broadcastId: string,
+    data: BroadcastTestOptions
+  ): Promise<BroadcastResponse> {
+    return await this.httpClient.post<BroadcastResponse>(
+      `/broadcasts/${encodeURIComponent(broadcastId)}/test`,
+      data
+    );
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,5 +1,8 @@
 /**
- * Package version used for user-agent and other version-related information
- * This is manually updated to match package.json version
+ * Package version, sent in the User-Agent header on every request.
+ *
+ * NOT updated automatically: semantic-release rewrites `package.json` only, so
+ * this must be bumped by hand alongside a release. It had drifted to 0.2.5
+ * while npm was already on 1.19.0, mislabelling all SDK traffic in telemetry.
  */
-export const VERSION = '0.2.5';
+export const VERSION = '1.19.0';

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import { ApiKeys } from './api/api-keys';
 import { Domains } from './api/domains';
 import { Events } from './api/events';
 import { Forms } from './api/forms';
+import { Broadcasts } from './api/broadcasts';
 import { HttpClient } from './utils/http-client';
 import { SmashSendClientOptions } from './interfaces/types';
 import {
@@ -52,6 +53,11 @@ export class SmashSend {
    */
   public readonly forms: Forms;
 
+  /**
+   * The Broadcasts API resource
+   */
+  public readonly broadcasts: Broadcasts;
+
   private httpClient: HttpClient;
 
   /**
@@ -83,6 +89,7 @@ export class SmashSend {
     this.emails = new Emails(this.httpClient);
     this.events = new Events(this.httpClient);
     this.forms = new Forms(this.httpClient);
+    this.broadcasts = new Broadcasts(this.httpClient);
     this.webhooks = new Webhooks(this.httpClient);
   }
 
@@ -204,6 +211,9 @@ export type {
   FormLeaderboardOptions,
   FormLeaderboardResponse,
 } from './interfaces/forms';
+
+// Export broadcasts types
+export * from './interfaces/broadcasts';
 
 // Export domain types
 export type {

--- a/src/interfaces/broadcasts.ts
+++ b/src/interfaces/broadcasts.ts
@@ -1,0 +1,77 @@
+/**
+ * Broadcasts API types.
+ *
+ * See https://smashsend.com/docs/api/broadcasts
+ *
+ * The Broadcasts API requires the Email API add-on, a verified workspace and
+ * the early-access flag on your workspace.
+ */
+
+export interface BroadcastAudience {
+  /** Send to every subscribed contact in the workspace. */
+  all?: boolean;
+  [key: string]: any;
+}
+
+export interface BroadcastSettings {
+  trackOpens?: boolean;
+  trackClicks?: boolean;
+}
+
+export interface BroadcastCreateOptions {
+  /** Internal name shown in your dashboard. Defaults to the subject. */
+  name?: string;
+  /** Email subject line. Supports {{variables}}. */
+  subject: string;
+  previewText?: string;
+  fromEmail: string;
+  /** Sender display name. Defaults to your workspace name. */
+  fromName?: string;
+  replyTo?: string[];
+  html: string;
+  text?: string;
+  audience: BroadcastAudience;
+  settings?: BroadcastSettings;
+  allowUnknownVariables?: boolean;
+}
+
+export interface Broadcast {
+  id: string;
+  name?: string;
+  subject: string;
+  status: string;
+  createdAt: string;
+  [key: string]: any;
+}
+
+export interface BroadcastResponse {
+  broadcast: Broadcast;
+}
+
+export interface BroadcastListOptions {
+  status?: string;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface BroadcastListResponse {
+  broadcasts: {
+    cursor: string | null;
+    hasMore: boolean;
+    items: Broadcast[];
+  };
+}
+
+export interface BroadcastScheduleOptions {
+  /** ISO 8601 timestamp. Omit to send immediately, if supported. */
+  sendAt?: string;
+  deliveryMethod?: string;
+}
+
+export interface BroadcastTestOptions {
+  /**
+   * Test recipients. Must be members of your workspace. The email is sent with
+   * a [TEST] subject prefix.
+   */
+  emails: string[];
+}


### PR DESCRIPTION
Adds smashsend.broadcasts with create/list/get/schedule/cancel/sendTest, mapping the public /v1/broadcasts endpoints. Requires the Email API add-on, a verified workspace and the early-access flag.

Also fixes VERSION in src/constants.ts, which was pinned at 0.2.5 while the package published as 1.19.0 - every request sent a wrong User-Agent.